### PR TITLE
Adding a test for doing a pull while stashing untracked changes

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/PullCommandTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/PullCommandTest.java
@@ -184,6 +184,35 @@ public class PullCommandTest extends RepositoryTestCase {
 	}
 
 	@Test
+	public void testPullWithUntrackedStash() throws Exception {
+		PullResult res = target.pull().call();
+		// nothing to update since we don't have different data yet
+		assertTrue(res.getFetchResult().getTrackingRefUpdates().isEmpty());
+		assertTrue(res.getMergeResult().getMergeStatus()
+				.equals(MergeStatus.ALREADY_UP_TO_DATE));
+
+		// change the source file
+		writeToFile(sourceFile, "Source change");
+		source.add().addFilepattern("SomeFile.txt").call();
+		source.commit().setMessage("Source change in remote").call();
+
+		// write untracked file
+		writeToFile(new File(dbTarget.getWorkTree(), "untracked.txt"),
+				"untracked");
+
+		RevCommit revCommit = target.stashCreate()
+				.setIndexMessage("message here").setIncludeUntracked(true)
+				.call();
+
+		assertNotNull(revCommit);
+		String stashName = revCommit.getName();
+
+		res = target.pull().call();
+
+		target.stashApply().setStashRef(stashName).call();
+	}
+
+	@Test
 	public void testPullLocalConflict() throws Exception {
 		target.branchCreate().setName("basedOnMaster").setStartPoint(
 				"refs/heads/master").setUpstreamMode(SetupUpstreamMode.TRACK)


### PR DESCRIPTION
Getting a conflict exception when I apply a stash with untracked files. I added a test method (testPullWithUntrackedStash) to PullCommandTest that should reproduce the issue.

1) Create an untracked file
2) Create a stash that contains the untracked file
3) Pull changes from another repository
4) Apply the stash you created
5) Trace is thrown

org.eclipse.jgit.api.errors.StashApplyFailureException: Applying stashed changes resulted in a conflict
	at org.eclipse.jgit.api.StashApplyCommand.call(StashApplyCommand.java:239)
	at org.eclipse.jgit.api.PullCommandTest.testPullWithUntrackedStash(PullCommandTest.java:212)
