### PR TITLE
Updated core manifest import

### DIFF
--- a/org.eclipse.jgit/META-INF/MANIFEST.MF
+++ b/org.eclipse.jgit/META-INF/MANIFEST.MF
@@ -135,8 +135,8 @@ Export-Package: org.eclipse.jgit.annotations;version="4.3.1",
    org.ietf.jgss",
  org.eclipse.jgit.util.io;version="4.3.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: com.jcraft.jsch;bundle-version="[0.1.37,0.2.0)"
 Import-Package: com.googlecode.javaewah;version="[0.7.9,0.8.0)",
+ com.jcraft.jsch;version="[0.1.37,0.2.0)", com.jcraft.jsch.jcraft;version="[0.1.37,0.2.0)",com.jcraft.jsch.jce;version="[0.1.37,0.2.0)",
  javax.crypto,
  javax.net.ssl,
  org.slf4j;version="[1.7.0,2.0.0)",


### PR DESCRIPTION
Problem resolving jsch dependencies under OSGI due to require-bundle usage. Jsch moved to Import-Package in manifest.
Same issue as reported here : https://bugs.eclipse.org/bugs/show_bug.cgi?id=359288