### PR TITLE
Set commit time to ZipArchiveEntry

### DIFF
--- a/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TarFormat.java
+++ b/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TarFormat.java
@@ -57,6 +57,7 @@ import org.apache.commons.compress.archivers.tar.TarConstants;
 import org.eclipse.jgit.api.ArchiveCommand;
 import org.eclipse.jgit.archive.internal.ArchiveText;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 
 /**
@@ -85,7 +86,7 @@ public final class TarFormat extends BaseFormat implements
 	}
 
 	public void putEntry(ArchiveOutputStream out,
-			String path, FileMode mode, ObjectLoader loader)
+			ObjectId tree, String path, FileMode mode, ObjectLoader loader)
 			throws IOException {
 		if (mode == FileMode.SYMLINK) {
 			final TarArchiveEntry entry = new TarArchiveEntry(

--- a/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/Tbz2Format.java
+++ b/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/Tbz2Format.java
@@ -53,6 +53,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.eclipse.jgit.api.ArchiveCommand;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 
 /**
@@ -81,9 +82,9 @@ public final class Tbz2Format extends BaseFormat implements
 	}
 
 	public void putEntry(ArchiveOutputStream out,
-			String path, FileMode mode, ObjectLoader loader)
+			ObjectId tree, String path, FileMode mode, ObjectLoader loader)
 			throws IOException {
-		tarFormat.putEntry(out, path, mode, loader);
+		tarFormat.putEntry(out, tree, path, mode, loader);
 	}
 
 	public Iterable<String> suffixes() {

--- a/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TgzFormat.java
+++ b/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TgzFormat.java
@@ -53,6 +53,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.eclipse.jgit.api.ArchiveCommand;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 
 /**
@@ -81,9 +82,9 @@ public final class TgzFormat extends BaseFormat implements
 	}
 
 	public void putEntry(ArchiveOutputStream out,
-			String path, FileMode mode, ObjectLoader loader)
+			ObjectId tree, String path, FileMode mode, ObjectLoader loader)
 			throws IOException {
-		tarFormat.putEntry(out, path, mode, loader);
+		tarFormat.putEntry(out, tree, path, mode, loader);
 	}
 
 	public Iterable<String> suffixes() {

--- a/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TxzFormat.java
+++ b/org.eclipse.jgit.archive/src/org/eclipse/jgit/archive/TxzFormat.java
@@ -53,6 +53,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.compressors.xz.XZCompressorOutputStream;
 import org.eclipse.jgit.api.ArchiveCommand;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 
 /**
@@ -81,9 +82,9 @@ public final class TxzFormat extends BaseFormat implements
 	}
 
 	public void putEntry(ArchiveOutputStream out,
-			String path, FileMode mode, ObjectLoader loader)
+			ObjectId tree, String path, FileMode mode, ObjectLoader loader)
 			throws IOException {
-		tarFormat.putEntry(out, path, mode, loader);
+		tarFormat.putEntry(out, tree, path, mode, loader);
 	}
 
 	public Iterable<String> suffixes() {

--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/ArchiveCommandTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/ArchiveCommandTest.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.junit.RepositoryTestCase;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.util.StringUtils;
@@ -224,7 +225,7 @@ public class ArchiveCommandTest extends RepositoryTestCase {
 			return new MockOutputStream();
 		}
 
-		public void putEntry(MockOutputStream out, String path, FileMode mode, ObjectLoader loader) {
+		public void putEntry(MockOutputStream out, ObjectId tree, String path, FileMode mode, ObjectLoader loader) {
 			String content = mode != FileMode.TREE ? new String(loader.getBytes()) : null;
 			entries.put(path, content);
 		}

--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/ArchiveCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/ArchiveCommand.java
@@ -161,6 +161,8 @@ public class ArchiveCommand extends GitCommand<OutputStream> {
 		 *
 		 * @param out
 		 *            archive object from createArchiveOutputStream
+		 * @param tree
+		 *            the tag, commit, or tree object to produce an archive for
 		 * @param path
 		 *            full filename relative to the root of the archive
 		 *            (with trailing '/' for directories)
@@ -173,7 +175,7 @@ public class ArchiveCommand extends GitCommand<OutputStream> {
 		 * @throws IOException
 		 *            thrown by the underlying output stream for I/O errors
 		 */
-		void putEntry(T out, String path, FileMode mode,
+		void putEntry(T out, ObjectId tree, String path, FileMode mode,
 				ObjectLoader loader) throws IOException;
 
 		/**
@@ -389,11 +391,11 @@ public class ArchiveCommand extends GitCommand<OutputStream> {
 						mode = FileMode.TREE;
 
 					if (mode == FileMode.TREE) {
-						fmt.putEntry(outa, name + "/", mode, null); //$NON-NLS-1$
+						fmt.putEntry(outa, tree, name + "/", mode, null); //$NON-NLS-1$
 						continue;
 					}
 					walk.getObjectId(idBuf, 0);
-					fmt.putEntry(outa, name, mode, reader.open(idBuf));
+					fmt.putEntry(outa, tree, name, mode, reader.open(idBuf));
 				}
 				outa.close();
 				return out;


### PR DESCRIPTION
Archived zip files for a same commit have different MD5 hash because mdate and mdate in the header of zip entries are not specified. In this case, Commons Compress sets an archived time.

In the original git implementation, it's set a commit time: 
https://github.com/git/git/blob/e2b2d6a172b76d44cb7b1ddb12ea5bfac9613a44/archive.c#L378

This pull request fix to set a commit time to ZipArchiveEntry when RevCommit is given as an archiving target.