### PR TITLE
Follow redirects in transport

### DIFF
--- a/org.eclipse.jgit.http.test/tst/org/eclipse/jgit/http/test/SmartClientSmartServerTest.java
+++ b/org.eclipse.jgit.http.test/tst/org/eclipse/jgit/http/test/SmartClientSmartServerTest.java
@@ -112,6 +112,7 @@ import org.eclipse.jgit.transport.http.JDKHttpConnectionFactory;
 import org.eclipse.jgit.transport.http.apache.HttpClientConnectionFactory;
 import org.eclipse.jgit.transport.resolver.RepositoryResolver;
 import org.eclipse.jgit.transport.resolver.ServiceNotEnabledException;
+import org.eclipse.jgit.util.HttpSupport;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -127,6 +128,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 	private URIish remoteURI;
 
 	private URIish brokenURI;
+
+	private URIish redirectURI;
 
 	private RevBlob A_txt;
 
@@ -155,40 +158,20 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 				.setBoolean(ConfigConstants.CONFIG_CORE_SECTION, null,
 						ConfigConstants.CONFIG_KEY_LOGALLREFUPDATES, true);
 
-		ServletContextHandler app = server.addContext("/git");
 		GitServlet gs = new GitServlet();
-		gs.setRepositoryResolver(new TestRepoResolver(src, srcName));
-		app.addServlet(new ServletHolder(gs), "/*");
 
-		ServletContextHandler broken = server.addContext("/bad");
-		broken.addFilter(new FilterHolder(new Filter() {
-			public void doFilter(ServletRequest request,
-					ServletResponse response, FilterChain chain)
-					throws IOException, ServletException {
-				final HttpServletResponse r = (HttpServletResponse) response;
-				r.setContentType("text/plain");
-				r.setCharacterEncoding("UTF-8");
-				PrintWriter w = r.getWriter();
-				w.print("OK");
-				w.close();
-			}
+		ServletContextHandler app = addNormalContext(gs, src, srcName);
 
-			public void init(FilterConfig filterConfig) throws ServletException {
-				//
-			}
+		ServletContextHandler broken = addBrokenContext(gs, src, srcName);
 
-			public void destroy() {
-				//
-			}
-		}), "/" + srcName + "/git-upload-pack",
-				EnumSet.of(DispatcherType.REQUEST));
-		broken.addServlet(new ServletHolder(gs), "/*");
+		ServletContextHandler redirect = addRedirectContext(gs, src, srcName);
 
 		server.setUp();
 
 		remoteRepository = src.getRepository();
 		remoteURI = toURIish(app, srcName);
 		brokenURI = toURIish(broken, srcName);
+		redirectURI = toURIish(redirect, srcName);
 
 		A_txt = src.blob("A");
 		A = src.commit().add("A_txt", A_txt).create();
@@ -196,6 +179,70 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		src.update(master, B);
 
 		src.update("refs/garbage/a/very/long/ref/name/to/compress", B);
+	}
+
+	private ServletContextHandler addNormalContext(GitServlet gs, TestRepository<Repository> src, String srcName) {
+		ServletContextHandler app = server.addContext("/git");
+
+		gs.setRepositoryResolver(new TestRepoResolver(src, srcName));
+		app.addServlet(new ServletHolder(gs), "/*");
+		return app;
+	}
+
+	private ServletContextHandler addBrokenContext(GitServlet gs, TestRepository<Repository> src, String srcName) {
+		ServletContextHandler broken = server.addContext("/bad");
+		broken.addFilter(new FilterHolder(new Filter() {
+					public void doFilter(ServletRequest request,
+										 ServletResponse response, FilterChain chain)
+							throws IOException, ServletException {
+						final HttpServletResponse r = (HttpServletResponse) response;
+						r.setContentType("text/plain");
+						r.setCharacterEncoding("UTF-8");
+						PrintWriter w = r.getWriter();
+						w.print("OK");
+						w.close();
+					}
+
+					public void init(FilterConfig filterConfig) throws ServletException {
+						//
+					}
+
+					public void destroy() {
+						//
+					}
+				}), "/" + srcName + "/git-upload-pack",
+				EnumSet.of(DispatcherType.REQUEST));
+		broken.addServlet(new ServletHolder(gs), "/*");
+		return broken;
+	}
+
+	private ServletContextHandler addRedirectContext(GitServlet gs, TestRepository<Repository> src, String srcName) {
+		ServletContextHandler redirect = server.addContext("/redirect");
+		redirect.addFilter(new FilterHolder(new Filter() {
+			@Override
+			public void init(FilterConfig filterConfig) throws ServletException {
+			}
+
+			@Override
+			public void doFilter(ServletRequest request,
+								 ServletResponse response, FilterChain chain) throws IOException, ServletException {
+				final HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+				final HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+				final StringBuffer fullUrl = httpServletRequest.getRequestURL();
+				if (httpServletRequest.getQueryString() != null) {
+					fullUrl.append("?").append(httpServletRequest.getQueryString());
+				}
+				httpServletResponse.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+				httpServletResponse.setHeader(HttpSupport.HDR_LOCATION, fullUrl.toString().replace("/redirect", "/git"));
+			}
+
+			@Override
+			public void destroy() {
+
+			}
+		}), "/*", EnumSet.of(DispatcherType.REQUEST));
+		redirect.addServlet(new ServletHolder(gs), "/*");
+		return redirect;
 	}
 
 	@Test
@@ -298,6 +345,52 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		assertEquals("gzip", info.getResponseHeader(HDR_CONTENT_ENCODING));
 
 		AccessEvent service = requests.get(1);
+		assertEquals("POST", service.getMethod());
+		assertEquals(join(remoteURI, "git-upload-pack"), service.getPath());
+		assertEquals(0, service.getParameters().size());
+		assertNotNull("has content-length", service
+				.getRequestHeader(HDR_CONTENT_LENGTH));
+		assertNull("not chunked", service
+				.getRequestHeader(HDR_TRANSFER_ENCODING));
+
+		assertEquals(200, service.getStatus());
+		assertEquals("application/x-git-upload-pack-result", service
+				.getResponseHeader(HDR_CONTENT_TYPE));
+	}
+
+	@Test
+	public void testInitialClone_RedirectSmall() throws Exception {
+		Repository dst = createBareRepository();
+		assertFalse(dst.hasObject(A_txt));
+
+		try (Transport t = Transport.open(dst, redirectURI)) {
+			t.fetch(NullProgressMonitor.INSTANCE, mirror(master));
+		}
+
+		assertTrue(dst.hasObject(A_txt));
+		assertEquals(B, dst.exactRef(master).getObjectId());
+		fsck(dst, B);
+
+		List<AccessEvent> requests = getRequests();
+		assertEquals(4, requests.size());
+
+		AccessEvent firstRedirect=requests.get(0);
+		assertEquals(301,firstRedirect.getStatus());
+
+		AccessEvent info = requests.get(1);
+		assertEquals("GET", info.getMethod());
+		assertEquals(join(remoteURI, "info/refs"), info.getPath());
+		assertEquals(1, info.getParameters().size());
+		assertEquals("git-upload-pack", info.getParameter("service"));
+		assertEquals(200, info.getStatus());
+		assertEquals("application/x-git-upload-pack-advertisement", info
+				.getResponseHeader(HDR_CONTENT_TYPE));
+		assertEquals("gzip", info.getResponseHeader(HDR_CONTENT_ENCODING));
+
+		AccessEvent secondRedirect=requests.get(2);
+		assertEquals(301,secondRedirect.getStatus());
+
+		AccessEvent service = requests.get(3);
 		assertEquals("POST", service.getMethod());
 		assertEquals(join(remoteURI, "git-upload-pack"), service.getPath());
 		assertEquals(0, service.getParameters().size());

--- a/org.eclipse.jgit/src/org/eclipse/jgit/transport/TransportHttp.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/transport/TransportHttp.java
@@ -52,6 +52,7 @@ import static org.eclipse.jgit.util.HttpSupport.HDR_ACCEPT;
 import static org.eclipse.jgit.util.HttpSupport.HDR_ACCEPT_ENCODING;
 import static org.eclipse.jgit.util.HttpSupport.HDR_CONTENT_ENCODING;
 import static org.eclipse.jgit.util.HttpSupport.HDR_CONTENT_TYPE;
+import static org.eclipse.jgit.util.HttpSupport.HDR_LOCATION;
 import static org.eclipse.jgit.util.HttpSupport.HDR_PRAGMA;
 import static org.eclipse.jgit.util.HttpSupport.HDR_USER_AGENT;
 import static org.eclipse.jgit.util.HttpSupport.HDR_WWW_AUTHENTICATE;
@@ -898,9 +899,13 @@ public class TransportHttp extends HttpTransport implements WalkTransport,
 		}
 
 		void openStream() throws IOException {
+			openStream(null);
+		}
+
+		void openStream(final String redirectUrl) throws IOException {
 			conn = httpOpen(
 					METHOD_POST,
-					new URL(baseUrl, serviceName),
+					redirectUrl == null ? new URL(baseUrl, serviceName) : new URL(redirectUrl),
 					AcceptEncoding.GZIP);
 			conn.setInstanceFollowRedirects(false);
 			conn.setDoOutput(true);
@@ -909,6 +914,10 @@ public class TransportHttp extends HttpTransport implements WalkTransport,
 		}
 
 		void sendRequest() throws IOException {
+			sendRequest(null);
+		}
+
+		void sendRequest(final String redirectUrl) throws IOException {
 			// Try to compress the content, but only if that is smaller.
 			TemporaryBuffer buf = new TemporaryBuffer.Heap(http.postBuffer);
 			try {
@@ -923,7 +932,7 @@ public class TransportHttp extends HttpTransport implements WalkTransport,
 				buf = out;
 			}
 
-			openStream();
+			openStream(redirectUrl);
 			if (buf != out)
 				conn.setRequestProperty(HDR_CONTENT_ENCODING, ENCODING_GZIP);
 			conn.setFixedLengthStreamingMode((int) buf.length());
@@ -932,6 +941,12 @@ public class TransportHttp extends HttpTransport implements WalkTransport,
 				buf.writeTo(httpOut, null);
 			} finally {
 				httpOut.close();
+			}
+
+			final int status = HttpSupport.response(conn);
+			if (status == HttpConnection.HTTP_MOVED_PERM) {
+				String locationHeader = HttpSupport.responseHeader(conn, HDR_LOCATION);
+				sendRequest(locationHeader);
 			}
 		}
 

--- a/org.eclipse.jgit/src/org/eclipse/jgit/transport/http/HttpConnection.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/transport/http/HttpConnection.java
@@ -71,6 +71,10 @@ public interface HttpConnection {
 	 * @see HttpURLConnection#HTTP_OK
 	 */
 	public static final int HTTP_OK = java.net.HttpURLConnection.HTTP_OK;
+	/**
+	 * @see HttpURLConnection#HTTP_MOVED_PERM
+	 */
+	public static final int HTTP_MOVED_PERM = java.net.HttpURLConnection.HTTP_MOVED_PERM;
 
 	/**
 	 * @see HttpURLConnection#HTTP_NOT_FOUND

--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/HttpSupport.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/HttpSupport.java
@@ -141,6 +141,9 @@ public class HttpSupport {
 	/** The {@code Accept-Encoding} header. */
 	public static final String HDR_ACCEPT_ENCODING = "Accept-Encoding"; //$NON-NLS-1$
 
+	/** The {@code Location} header. */
+	public static final String HDR_LOCATION = "Location"; //$NON-NLS-1$
+
 	/** The {@code gzip} encoding value for {@link #HDR_ACCEPT_ENCODING}. */
 	public static final String ENCODING_GZIP = "gzip"; //$NON-NLS-1$
 
@@ -232,6 +235,18 @@ public class HttpSupport {
 						JGitText.get().connectionTimeOut, host));
 			throw new ConnectException(ce.getMessage() + " " + host); //$NON-NLS-1$
 		}
+	}
+
+	/**
+	 * Extract a HTTP header from the response.
+	 * @param c connection the header should be obtained from.
+	 * @param headerField the header name
+	 * @return the header value
+	 * @throws IOException
+	 *             communications error prevented obtaining the header.
+	 */
+	public static String responseHeader(final HttpConnection c, final String headerField) throws IOException {
+		return c.getHeaderField(headerField);
 	}
 
 	/**


### PR DESCRIPTION
JGit will throw an exception when cloning some repos such as `https://gopkg.in/ini.v1`, which git cli could handle properly. This bug was also reported [here](https://bugs.eclipse.org/bugs/show_bug.cgi?id=465167).

The reason was that JGit would not POST a request again when encountering `301 Moved Permanently`, for example, `POST <repository>/git-upload-pack`.

This PR fixed this issue, and a test was added in the case mentioned above.

Signed-off-by: Bo Zhang <zhangbodut@gmail.com>

