### PR TITLE
Fix JGit set core.fileMode to false by default instead of true for none Windows OS

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/FS_POSIX.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/FS_POSIX.java
@@ -188,7 +188,7 @@ public class FS_POSIX extends FS {
 		if (!isFile(f))
 			return false;
 		if (!canExecute)
-			return f.setExecutable(false);
+			return f.setExecutable(false, false);
 
 		try {
 			Path path = f.toPath();


### PR DESCRIPTION
[Issue 519887](https://bugs.eclipse.org/bugs/show_bug.cgi?id=519887)