### PR TITLE
Fix and resolution for issue 531075

### DIFF
--- a/org.eclipse.jgit.http.server/src/org/eclipse/jgit/http/server/WWWAuthenticationFilter.java
+++ b/org.eclipse.jgit.http.server/src/org/eclipse/jgit/http/server/WWWAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package org.eclipse.jgit.http.server;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.eclipse.jgit.util.HttpSupport.HDR_WWW_AUTHENTICATE;
+
+/**
+ * In case of HTTP 401 status, ensures WWW-Authentication header is included
+ * in response header.
+ */
+public class WWWAuthenticationFilter implements Filter {
+
+    private String realmName;
+
+    public WWWAuthenticationFilter(String realmName) {
+        this.realmName = realmName;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void init(FilterConfig config) throws ServletException {
+        // Do nothing.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void destroy() {
+        // Do nothing.
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response,
+            FilterChain chain) throws IOException, ServletException {
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            HttpServletResponse rsp = (HttpServletResponse) response;
+            if (rsp.getStatus() == SC_UNAUTHORIZED && rsp.getHeader(HDR_WWW_AUTHENTICATE) == null) {
+                rsp.setHeader(HDR_WWW_AUTHENTICATE, String.format("Basic realm=\"%s\"", realmName));
+            }
+        }
+    }
+
+
+}

--- a/org.eclipse.jgit.http.test/tst/org/eclipse/jgit/http/test/SmartClientSmartServerTest.java
+++ b/org.eclipse.jgit.http.test/tst/org/eclipse/jgit/http/test/SmartClientSmartServerTest.java
@@ -44,9 +44,7 @@
 package org.eclipse.jgit.http.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.eclipse.jgit.util.HttpSupport.HDR_CONTENT_ENCODING;
-import static org.eclipse.jgit.util.HttpSupport.HDR_CONTENT_LENGTH;
-import static org.eclipse.jgit.util.HttpSupport.HDR_CONTENT_TYPE;
+import static org.eclipse.jgit.util.HttpSupport.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -722,6 +720,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		AccessEvent info = requests.get(0);
 		assertEquals("GET", info.getMethod());
 		assertEquals(401, info.getStatus());
+		assertNotNull(info.getResponseHeader(HDR_WWW_AUTHENTICATE));
+		assertTrue(info.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
 
 		info = requests.get(1);
 		assertEquals("GET", info.getMethod());
@@ -767,6 +767,9 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		AccessEvent info = requests.get(0);
 		assertEquals("GET", info.getMethod());
 		assertEquals(401, info.getStatus());
+		assertNotNull(info.getResponseHeader(HDR_WWW_AUTHENTICATE));
+		assertTrue(info.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
+
 	}
 
 	@Test
@@ -792,6 +795,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		for (AccessEvent event : requests) {
 			assertEquals("GET", event.getMethod());
 			assertEquals(401, event.getStatus());
+			assertNotNull(event.getResponseHeader(HDR_WWW_AUTHENTICATE));
+			assertTrue(event.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
 		}
 	}
 
@@ -839,6 +844,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		assertEquals("GET", info.getMethod());
 		assertEquals(join(authURI, "info/refs"), info.getPath());
 		assertEquals(401, info.getStatus());
+		assertNotNull(info.getResponseHeader(HDR_WWW_AUTHENTICATE));
+		assertTrue(info.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
 
 		info = requests.get(2);
 		assertEquals("GET", info.getMethod());
@@ -896,6 +903,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		assertEquals("POST", service.getMethod());
 		assertEquals(join(authOnPostURI, "git-upload-pack"), service.getPath());
 		assertEquals(401, service.getStatus());
+		assertNotNull(service.getResponseHeader(HDR_WWW_AUTHENTICATE));
+		assertTrue(service.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
 
 		service = requests.get(2);
 		assertEquals("POST", service.getMethod());
@@ -1181,6 +1190,8 @@ public class SmartClientSmartServerTest extends HttpTestCase {
 		assertEquals(1, info.getParameters().size());
 		assertEquals("git-receive-pack", info.getParameter("service"));
 		assertEquals(401, info.getStatus());
+		assertNotNull(info.getResponseHeader(HDR_WWW_AUTHENTICATE));
+		assertTrue(info.getResponseHeader(HDR_WWW_AUTHENTICATE).toLowerCase().startsWith("basic realm="));
 	}
 
 	@Test


### PR DESCRIPTION
HTTP server does not include "WWW-Authenticate" header when an underlying call, e.g. "RepositoryResolver.open", throws "ServiceNotAuthorizedException".

This situation violates Section 10.16 of RFC 1945. As a result, Git clients fail to challenge the user to enter their credentials and retry the request.
