### PR TITLE
resolve the problem "not in non blocking mode" when download large file

### DIFF
--- a/org.eclipse.jgit.lfs.server/src/org/eclipse/jgit/lfs/server/fs/ObjectDownloadListener.java
+++ b/org.eclipse.jgit.lfs.server/src/org/eclipse/jgit/lfs/server/fs/ObjectDownloadListener.java
@@ -129,6 +129,7 @@ public class ObjectDownloadListener implements WriteListener {
 						outChannel.write(buffer);
 					} else {
 						context.complete();
+						return;
 					}
 				}
 			}


### PR DESCRIPTION
when I use the lfs api to implement lfs server. 
when I git lfs fetch the large file, I get the problem, like this:

INFO  ObjectDownloadListener  - not in non blocking mode.
java.lang.IllegalStateException: not in non blocking mode.
	at org.apache.coyote.Response.isReady(Response.java:599)
	at org.apache.catalina.connector.OutputBuffer.isReady(OutputBuffer.java:668)
	at org.apache.catalina.connector.CoyoteOutputStream.isReady(CoyoteOutputStream.java:156)
	at org.eclipse.jgit.lfs.server.fs.ObjectDownloadListener.onWritePossible(ObjectDownloadListener.java:136)
	at org.apache.coyote.Response.onWritePossible(Response.java:638)
	at org.apache.catalina.connector.CoyoteAdapter.asyncDispatch(CoyoteAdapter.java:320)
	at org.apache.coyote.http11.AbstractHttp11Processor.asyncDispatch(AbstractHttp11Processor.java:1754)
	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:655)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1539)
	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1495)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
	at java.lang.Thread.run(Thread.java:748)