### PR TITLE
Fix return 'this' in setters in StashApplyCommand

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/StashApplyCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/StashApplyCommand.java
@@ -277,9 +277,11 @@ public class StashApplyCommand extends GitCommand<ObjectId> {
 	 *
 	 * @param applyIndex
 	 *            true (default) if the command should restore the index state
+	 * @return {@code this}
 	 */
-	public void setApplyIndex(boolean applyIndex) {
+	public StashApplyCommand setApplyIndex(boolean applyIndex) {
 		this.applyIndex = applyIndex;
+		return this;
 	}
 
 	/**
@@ -301,10 +303,12 @@ public class StashApplyCommand extends GitCommand<ObjectId> {
 	 *
 	 * @param applyUntracked
 	 *            true (default) if the command should restore untracked files
+	 * @return {@code this}
 	 * @since 3.4
 	 */
-	public void setApplyUntracked(boolean applyUntracked) {
+	public StashApplyCommand setApplyUntracked(boolean applyUntracked) {
 		this.applyUntracked = applyUntracked;
+		return this;
 	}
 
 	private void resetIndex(RevTree tree) throws IOException {


### PR DESCRIPTION
'setApplyIndex' and 'setApplyUntracked' methods in StashApplyCommand don't return the current object.

This PR changes the return types of these methods to return 'this' as other methods do in other commands.