### PR TITLE
Maintain the original error message

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
@@ -636,12 +636,13 @@ public abstract class FS {
 							JGitText.get().commandClosedStderrButDidntExit,
 							desc, PROCESS_EXIT_TIMEOUT), -1);
 					fail.set(true);
+					return false;
 				}
 			} catch (InterruptedException e) {
 				LOG.error(MessageFormat.format(
 						JGitText.get().threadInterruptedWhileRunning, desc), e);
 			}
-			return false;
+			return true;
 		}
 
 		private void setError(IOException e, String message, int exitCode) {


### PR DESCRIPTION
There is a bug since v4.9.2.201712150930-r. Whenever calling 'git --version' or 'git config --system --edit' fails, the error message is not set, causing the Log.warn() to be called with null. This is because waitForProcessCompletion always returned false.