### PR TITLE
Fix RemoteRemoveCommand.setName() not returning instance.

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/RemoteRemoveCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/RemoteRemoveCommand.java
@@ -84,9 +84,11 @@ public class RemoteRemoveCommand extends GitCommand<RemoteConfig> {
 	 *
 	 * @param name
 	 *            a remote name
+	 * @return this instance
 	 */
-	public void setName(String name) {
+	public RemoteRemoveCommand setName(String name) {
 		this.name = name;
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Unlike other GitCommand setters, setName() did not return the instance
preventing use of method chaining.