### PR TITLE
BUG:544336 fix

### DIFF
--- a/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/FetchCommandTest.java
+++ b/org.eclipse.jgit.test/tst/org/eclipse/jgit/api/FetchCommandTest.java
@@ -91,6 +91,9 @@ public class FetchCommandTest extends RepositoryTestCase {
 		remoteConfig.addURI(uri);
 		remoteConfig.update(config);
 		config.save();
+                
+		addRepoToClose(git.getRepository());
+		addRepoToClose(remoteGit.getRepository());
 	}
 
 	@Test


### PR DESCRIPTION
Tests should close all temporal repositories to free files for further deleting.
Windows cant remove opened files (it only marks them for the cleanup when the process finishes).
Then tt fails on removing "not_empty" directory.