### PR TITLE
Fix setRevFilter bug in call()

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/LogCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/LogCommand.java
@@ -160,7 +160,11 @@ public class LogCommand extends GitCommand<Iterable<RevCommit>> {
 		}
 
 		if (this.revFilter != null) {
-			walk.setRevFilter(this.revFilter);
+			if(walk.getRevFilter() != null) {
+				walk.setRevFilter(AndRevFilter.create(this.revFilter, walk.getRevFilter());
+			} else {
+				walk.setRevFilter(this.revFilter);
+			}
 		}
 
 		setCallable(false);


### PR DESCRIPTION
Example:
```java
LogCommand log = git.log();
// 1. set my custom filter  at first. 
log.setRevFilter(myCustomFilter);
// 2. set pagination params using setSkip() and setMaxCount()
log.setSkip(10).setMaxCount(10);
// 3. call(). myCustomFilter was dropped.
log.call();
```