### PR TITLE
add support for situation when pathInfo is null (for example in spring)

### DIFF
--- a/org.eclipse.jgit.http.server/src/org/eclipse/jgit/http/server/glue/SuffixPipeline.java
+++ b/org.eclipse.jgit.http.server/src/org/eclipse/jgit/http/server/glue/SuffixPipeline.java
@@ -97,10 +97,15 @@ class SuffixPipeline extends UrlPipeline {
 	@Override
 	void service(HttpServletRequest req, HttpServletResponse rsp)
 			throws ServletException, IOException {
-		String curInfo = req.getPathInfo();
+		String curInfo = getPathInfo(req);
 		String newPath = req.getServletPath() + curInfo;
 		String newInfo = curInfo.substring(0, curInfo.length() - suffixLen);
 		super.service(new WrappedRequest(req, newPath, newInfo), rsp);
+	}
+
+	private String getPathInfo(HttpServletRequest req) {
+		return req.getPathInfo() != null ? req.getPathInfo() :
+				req.getRequestURI().substring(req.getContextPath().length());
 	}
 
 	/** {@inheritDoc} */


### PR DESCRIPTION
In spring environment the method getPathInfo() returns null. This path allows to configure jgit http server with spring using servlet wrapping.

	@Bean
	public ServletWrappingController custom() {
		ServletWrappingController controller = new ServletWrappingController();
		controller.setServletName("custom");
		controller.setServletClass(CustomGitServlet.class);
		return controller;
	}

	@Bean
	public SimpleUrlHandlerMapping customMapping() {
		SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
		mapping.setDefaultHandler(custom());
		mapping.setOrder(Ordered.LOWEST_PRECEDENCE - 2);
		return mapping;
	}

