### PR TITLE
Make supportsAtomicCreateNewFile return true as default

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/FS_POSIX.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/FS_POSIX.java
@@ -358,6 +358,10 @@ public class FS_POSIX extends FS {
 	public boolean supportsAtomicCreateNewFile() {
 		if (supportsAtomicCreateNewFile == AtomicFileCreation.UNDEFINED) {
 			determineAtomicFileCreationSupport();
+
+			if (supportsAtomicCreateNewFile == AtomicFileCreation.UNDEFINED) {
+				supportsAtomicCreateNewFile = AtomicFileCreation.SUPPORTED;
+			}
 		}
 		return supportsAtomicCreateNewFile == AtomicFileCreation.SUPPORTED;
 	}


### PR DESCRIPTION
The method org.eclipse.jgit.util.FS.supportsAtomicCreateNewFile()
should default to true as mentioned in docs [1]

org.eclipse.jgit.util.FS_POSIX.supportsAtomicCreateNewFile() method
will set the value to false if the git config
core.supportsatomiccreatenewfile is not set.

It should default to true if the configuration is undefined.

[1]
https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/util/FS_POSIX.java#L372

Bug: 544164
Change-Id: I16ccf989a89da2cf4975c200b3228b25ba4c0d55
Signed-off-by: Vishal Devgire <vishaldevgire@gmail.com>