### PR TITLE
Proposed fix for Bug 548219

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/api/ApplyCommand.java
@@ -279,9 +279,12 @@ public class ApplyCommand extends GitCommand<ApplyResult> {
 	}
 
 	private boolean isNoNewlineAtEndOfFile(FileHeader fh) {
-		HunkHeader lastHunk = fh.getHunks().get(fh.getHunks().size() - 1);
-		RawText lhrt = new RawText(lastHunk.getBuffer());
-		return lhrt.getString(lhrt.size() - 1).equals(
-				"\\ No newline at end of file"); //$NON-NLS-1$
+		if (fh.getHunks() != null && fh.getHunks().size() > 0) {
+			HunkHeader lastHunk = fh.getHunks().get(fh.getHunks().size() - 1);
+			RawText lhrt = new RawText(lastHunk.getBuffer());
+			return lhrt.getString(lhrt.size() - 1)
+					.equals("\\ No newline at end of file"); //$NON-NLS-1$
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
Proposed fix for the Bug 548219 - ApplyCommand does not work if patch contains ADD of empty file.

Signed-off-by: Anton Khodos <khodosanton@gmail.com>