### PR TITLE
Allowing to create tags with a past timestamp

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/ReflogWriter.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/ReflogWriter.java
@@ -191,8 +191,6 @@ public class ReflogWriter {
 		PersonIdent ident = update.getRefLogIdent();
 		if (ident == null)
 			ident = new PersonIdent(refdb.getRepository());
-		else
-			ident = new PersonIdent(ident);
 
 		byte[] rec = encode(oldId, newId, ident, msg);
 		if (deref && ref.isSymbolic()) {


### PR DESCRIPTION
Removing these line will make it possible to create tags with a past timestamp. The functionality to use the current timestamp is not dropped since the PersonIdent when created and not given a timestamp will use the current time.