### PR TITLE
[548648] crashes with AccessDeniedException in GitBash

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/util/FS.java
@@ -200,7 +200,7 @@ public abstract class FS {
 		static Duration getFsTimestampResolution(Path file) {
 			try {
 				Path dir = Files.isDirectory(file) ? file : file.getParent();
-				if (!dir.toFile().canWrite()) {
+				if (!Files.isWritable(dir)) {
 					// can not determine FileStore of an unborn directory or in
 					// a read-only directory
 					return FALLBACK_TIMESTAMP_RESOLUTION;


### PR DESCRIPTION
Exception is still thrown, although there is this check for Writeable directory.
Reason:

* java.nio.file.Files.isWriteable doesn't agree with java.io.File.canWrite()
* AccessDeniedException is thrown by NIO Files.create, but File writeability is check with IO File.canWrite
* see https://stackoverflow.com/questions/12688287/java-nio-file-files-iswriteable-doesnt-agree-with-java-io-file-canwrite

* Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=548648
* Signed-off-by: Robert Kleinschmager <eclipse.foundation@kleinschmager.net>