### PR TITLE
Config: Remove unused dependency

### DIFF
--- a/org.eclipse.jgit/pom.xml
+++ b/org.eclipse.jgit/pom.xml
@@ -99,11 +99,6 @@
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
Dependency `org.bouncycastle:bcpkix-jdk15on` is declared in the `pom` but it is not used in the project. Hence, this dependency can be safely removed.