### PR TITLE
Avoid use of ConcurrentHashMap.keySet() to support Android (JDK 8).

### DIFF
--- a/org.eclipse.jgit/src/org/eclipse/jgit/attributes/FilterCommandRegistry.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/attributes/FilterCommandRegistry.java
@@ -12,6 +12,8 @@ package org.eclipse.jgit.attributes;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -82,7 +84,7 @@ public class FilterCommandRegistry {
 	 *         registered
 	 */
 	public static Set<String> getRegisteredFilterCommands() {
-		return filterCommandRegistry.keySet();
+		return new HashSet<>(Collections.list(filterCommandRegistry.keys()));
 	}
 
 	/**

--- a/org.eclipse.jgit/src/org/eclipse/jgit/lib/RepositoryCache.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/lib/RepositoryCache.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -276,7 +277,7 @@ public class RepositoryCache {
 	}
 
 	private Collection<Key> getKeys() {
-		return new ArrayList<>(cacheMap.keySet());
+        return Collections.list(cacheMap.keys());
 	}
 
 	private void clearAllExpired() {
@@ -288,9 +289,9 @@ public class RepositoryCache {
 	}
 
 	private void clearAll() {
-		for (Key k : cacheMap.keySet()) {
-			unregisterAndCloseRepository(k);
-		}
+        cacheMap.keys().asIterator().forEachRemaining(k -> {
+            unregisterAndCloseRepository(k);
+        });
 	}
 
 	private Lock lockFor(Key location) {


### PR DESCRIPTION
We are using jGit in one of our Android projects.
It seems that the implementation of ConcurrentHashMap is changed in Android.

This PR will avoid using KeySetView and use plain old Set to avoid Exceptions in Android.

